### PR TITLE
Ksp Workaround

### DIFF
--- a/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
+++ b/src/main/groovy/org/gradle/android/workarounds/RoomSchemaLocationWorkaround.groovy
@@ -223,6 +223,43 @@ class RoomSchemaLocationWorkaround implements Workaround {
             // maps annotation processor providers from the variant directly onto kapt tasks.
             javaCompileSchemaGenerationEnabled = false
         }
+
+
+        // Ksp Workaround implementation. Based on Kapt workaround
+        project.plugins.withId("com.google.devtools.ksp") {
+
+            // Ksp doesn't delegate to javac like kapt, we can use the task provider
+            project.tasks.withType(kspTaskClass).configureEach {
+
+                // Adding the Ksp CommandLineArgument with variant and room extension
+                def variantSpecificSchemaDir = project.objects.directoryProperty()
+                variantSpecificSchemaDir.set(getVariantSpecificSchemaDir(project, it.name))
+                it.commandLineArgumentProviders.add(new KspRoomSchemaLocationArgumentProvider(roomExtension.schemaLocationDir, variantSpecificSchemaDir))
+
+                def commandLineArgumentProviders = getAccessibleField(it.class, "__commandLineArgumentProviders__").get(it)
+
+                // We need to generate the schemas to a temporary directory and then copy them to the registered
+                // output directory.
+                doFirst onlyIfAnnotationProcessorConfiguredForKsp(commandLineArgumentProviders) { KspRoomSchemaLocationArgumentProvider provider ->
+                    RoomSchemaLocationWorkaround.copyExistingSchemasToTaskSpecificTmpDirForKsp(fileOperations, roomExtension.schemaLocationDir, provider)
+                }
+
+                doLast onlyIfAnnotationProcessorConfiguredForKsp(commandLineArgumentProviders) { KspRoomSchemaLocationArgumentProvider provider ->
+                    RoomSchemaLocationWorkaround.copyGeneratedSchemasToOutputDirForKsp(fileOperations, provider)
+                }
+
+                finalizedBy onlyIfAnnotationProcessorConfiguredForKsp(commandLineArgumentProviders) { roomExtension.schemaLocationDir.isPresent() ? mergeTask : null }
+
+                TaskExecutionGraph taskGraph = project.gradle.taskGraph
+
+                taskGraph.whenReady onlyIfAnnotationProcessorConfiguredForKsp(commandLineArgumentProviders) { KspRoomSchemaLocationArgumentProvider provider ->
+                    if (taskGraph.hasTask(it)) {
+                        roomExtension.registerOutputDirectory(provider.schemaLocationDir)
+                    }
+                }
+            }
+        }
+
     }
 
     private static void errorIfRoomSchemaAnnotationArgumentSet(Set<String> options) {
@@ -246,6 +283,15 @@ class RoomSchemaLocationWorkaround implements Workaround {
     private static Closure onlyIfAnnotationProcessorConfiguredForKapt(def annotationProcessorOptionProviders, Closure<?> action) {
         return {
             def provider = annotationProcessorOptionProviders.flatten().find { it instanceof KaptRoomSchemaLocationArgumentProvider }
+            if (provider != null) {
+                action.call(provider)
+            }
+        }
+    }
+
+    private static Closure onlyIfAnnotationProcessorConfiguredForKsp(def commandLineArgumentProviders, Closure<?> action) {
+        return {
+            def provider = commandLineArgumentProviders.get().find { it instanceof KspRoomSchemaLocationArgumentProvider }
             if (provider != null) {
                 action.call(provider)
             }
@@ -314,11 +360,29 @@ class RoomSchemaLocationWorkaround implements Workaround {
         copyExistingSchemasToTaskSpecificTmpDir(fileOperations, existingSchemaDir, temporaryVariantSpecificSchemaDir)
     }
 
+    private static void copyExistingSchemasToTaskSpecificTmpDirForKsp(FileOperations fileOperations, Provider<Directory> existingSchemaDir, KspRoomSchemaLocationArgumentProvider provider) {
+        // Derive the variant directory from the command line provider it is configured with
+        def temporaryVariantSpecificSchemaDir = provider.temporarySchemaLocationDir
+
+        // Populate the variant-specific temporary schema dir with the existing schemas
+        copyExistingSchemasToTaskSpecificTmpDir(fileOperations, existingSchemaDir, temporaryVariantSpecificSchemaDir)
+    }
+
     private static void copyGeneratedSchemasToOutputDirForKapt(FileOperations fileOperations, KaptRoomSchemaLocationArgumentProvider provider) {
         // Copy the generated generated schemas from the task-specific tmp dir to the
         // task-specific output dir.  This dance prevents the kapt task from clearing out
         // the existing schemas before the annotation processors run
         // Derive the variant directory from the command line provider it is configured with
+        def variantSpecificSchemaDir = provider.schemaLocationDir
+        def temporaryVariantSpecificSchemaDir = provider.temporarySchemaLocationDir
+
+        fileOperations.sync {
+            it.from temporaryVariantSpecificSchemaDir
+            it.into variantSpecificSchemaDir
+        }
+    }
+
+    private static void copyGeneratedSchemasToOutputDirForKsp(FileOperations fileOperations, KspRoomSchemaLocationArgumentProvider provider) {
         def variantSpecificSchemaDir = provider.schemaLocationDir
         def temporaryVariantSpecificSchemaDir = provider.temporarySchemaLocationDir
 
@@ -349,6 +413,10 @@ class RoomSchemaLocationWorkaround implements Workaround {
 
     static Class<?> getKaptWithKotlincTaskClass() {
         return Class.forName("org.jetbrains.kotlin.gradle.internal.KaptWithKotlincTask")
+    }
+
+    static Class<?> getKspTaskClass() {
+        return Class.forName("com.google.devtools.ksp.gradle.KspTaskJvm")
     }
 
     static VersionNumber getKotlinVersion() {
@@ -399,7 +467,12 @@ class RoomSchemaLocationWorkaround implements Workaround {
         @Override
         Iterable<String> asArguments() {
             if (configuredSchemaLocationDir.isPresent()) {
-                return ["-A${ROOM_SCHEMA_LOCATION}=${schemaLocationPath}" as String]
+               if(this instanceof KspRoomSchemaLocationArgumentProvider) {
+                   return ["${ROOM_SCHEMA_LOCATION}=${schemaLocationPath}" as String]
+               }else {
+                   return ["-A${ROOM_SCHEMA_LOCATION}=${schemaLocationPath}" as String]
+               }
+
             } else {
                 return []
             }
@@ -431,6 +504,20 @@ class RoomSchemaLocationWorkaround implements Workaround {
             return temporarySchemaLocationDir.get().asFile.absolutePath
         }
     }
+
+    static class KspRoomSchemaLocationArgumentProvider extends RoomSchemaLocationArgumentProvider {
+    private Provider<Directory> temporarySchemaLocationDir
+
+    KspRoomSchemaLocationArgumentProvider(Provider<Directory> configuredSchemaLocationDir, Provider<Directory> schemaLocationDir) {
+        super(configuredSchemaLocationDir, schemaLocationDir)
+        this.temporarySchemaLocationDir = schemaLocationDir.map { it.dir("../${it.asFile.name}Temp") }
+    }
+
+    @Override
+    protected String getSchemaLocationPath() {
+        return temporarySchemaLocationDir.get().asFile.absolutePath
+    }
+}
 
     static class MergeAssociations {
         final ObjectFactory objectFactory

--- a/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
+++ b/src/test/groovy/org/gradle/android/RoomSchemaLocationWorkaroundTest.groovy
@@ -322,6 +322,79 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         androidVersion << TestVersions.latestAndroidVersions
     }
 
+    @Unroll
+    def "schemas are correctly generated with Ksp when only one variant is built incrementally  (Android #androidVersion)"() {
+        SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
+            .withAndroidVersion(androidVersion)
+            .withKotlinVersion(TestVersions.latestSupportedKotlinVersion())
+            .withKsp()
+            .build()
+            .writeProject()
+
+        cacheDir.deleteDir()
+        cacheDir.mkdirs()
+
+        when:
+        BuildResult buildResult = withGradleVersion(TestVersions.latestSupportedGradleVersionFor(androidVersion).version)
+            .forwardOutput()
+            .withProjectDir(temporaryFolder.root)
+            .withArguments(CLEAN_BUILD)
+            .build()
+
+        then:
+        assertCompileTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertCompileUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKspTasksHaveOutcome(buildResult, SUCCESS)
+        assertKspAndroidTestTasksHaveOutcome(buildResult, SUCCESS)
+        assertKspUnitTestTasksHaveOutcome(buildResult, SUCCESS)
+
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
+
+        and:
+        assertKspSchemaOutputsExist()
+
+        and:
+        assertMergedSchemaOutputsExist()
+
+        and:
+        assertKspSchemaContainsColumnFor('last_update', 'debug')
+
+        and:
+        assertMergedRoomSchemaContainsColumn("last_update")
+
+        when:
+        modifyRoomColumnName("last_update", "foo")
+        buildResult = withGradleVersion(TestVersions.latestSupportedGradleVersionFor(androidVersion).version)
+            .forwardOutput()
+            .withProjectDir(temporaryFolder.root)
+            .withArguments(INCREMENTAL_DEBUG_BUILD)
+            .build()
+
+        then:
+        assertCompileTasksHaveOutcome(buildResult, SUCCESS, ["debug"])
+        assertKspTasksHaveOutcome(buildResult, SUCCESS, ["debug"])
+        buildResult.task(':app:mergeRoomSchemaLocations').outcome == SUCCESS
+        buildResult.task(':library:mergeRoomSchemaLocations').outcome == SUCCESS
+
+        and:
+        assertKspSchemaOutputsExist()
+
+        and:
+        assertMergedSchemaOutputsExist()
+
+        and:
+        assertKspSchemaContainsColumnFor('foo', 'debug')
+
+        and:
+        assertMergedRoomSchemaContainsColumn("foo")
+
+        where:
+        //noinspection GroovyAssignabilityCheck
+        androidVersion << TestVersions.latestAndroidVersions
+    }
+
     def "workaround throws an exception when room extension is not configured, but annotation processor argument is"() {
         def androidVersion = TestVersions.latestAndroidVersionForCurrentJDK()
         SimpleAndroidApp.builder(temporaryFolder.root, cacheDir)
@@ -539,6 +612,18 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
         assertAllVariantTasksHaveOutcome(buildResult, outcome, ALL_PROJECTS, variants) { project, variant -> ":${project}:kapt${variant.capitalize()}UnitTestKotlin" }
     }
 
+    void assertKspAndroidTestTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome, ALL_PROJECTS, ["debug"]) { project, variant -> ":${project}:ksp${variant.capitalize()}AndroidTestKotlin" }
+    }
+
+    void assertKspTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome, List<String> variants = ALL_VARIANTS) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome, ALL_PROJECTS, variants) { project, variant -> ":${project}:ksp${variant.capitalize()}Kotlin" }
+    }
+
+    void assertKspUnitTestTasksHaveOutcome(BuildResult buildResult, TaskOutcome outcome, List<String> variants = ALL_VARIANTS) {
+        assertAllVariantTasksHaveOutcome(buildResult, outcome, ALL_PROJECTS, variants) { project, variant -> ":${project}:ksp${variant.capitalize()}UnitTestKotlin" }
+    }
+
     void assertAllVariantTasksHaveOutcome(BuildResult buildResult, TaskOutcome taskOutcome, List<String> projects, List<String> variants, Closure<String> taskPathTransform) {
         projects.each { project ->
             variants.each { variant ->
@@ -556,6 +641,16 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
     void assertKaptSchemaOutputsExistFor(String variant) {
         assertSchemasExist("app", "build/roomSchemas/kapt${variant.capitalize()}Kotlin")
         assertSchemasExist("library", "build/roomSchemas/kapt${variant.capitalize()}Kotlin")
+    }
+
+    void assertKspSchemaOutputsExist() {
+        assertKspSchemaOutputsExistFor("debug")
+        assertKspSchemaOutputsExistFor("release")
+    }
+
+    void assertKspSchemaOutputsExistFor(String variant) {
+        assertSchemasExist("app", "build/roomSchemas/ksp${variant.capitalize()}Kotlin")
+        assertSchemasExist("library", "build/roomSchemas/ksp${variant.capitalize()}Kotlin")
     }
 
     void assertCompileJavaSchemaOutputsExist() {
@@ -593,6 +688,11 @@ class RoomSchemaLocationWorkaroundTest extends AbstractTest {
     void assertKaptSchemaContainsColumnFor(String columnName, String variant) {
         assertRoomSchemaContainsColumn("app", "build/roomSchemas/kapt${variant.capitalize()}Kotlin", columnName)
         assertRoomSchemaContainsColumn("library", "build/roomSchemas/kapt${variant.capitalize()}Kotlin", columnName)
+    }
+
+    void assertKspSchemaContainsColumnFor(String columnName, String variant) {
+        assertRoomSchemaContainsColumn("app", "build/roomSchemas/ksp${variant.capitalize()}Kotlin", columnName)
+        assertRoomSchemaContainsColumn("library", "build/roomSchemas/ksp${variant.capitalize()}Kotlin", columnName)
     }
 
     void assertMergedRoomSchemaContainsColumn(String columnName) {


### PR DESCRIPTION
## KspWorkarond
Draft of a POC for the Ksp workaround(This pr is pointing to the fork main branch).


### Implementation
Based on the Kapt implementation, the workaround adds a CommandlineArgument on the KspTasks representing a roomschema location based on the ksp task variant(name in this case).

Because Ksp has the same issue as Kapt with the removed output directories, we generate schemas to a temporary directory, then copy them to the registered output directory.

#### Notes
* We don't need to provide `-A` in the command line argument provider because is handled by Ksp.


### Tests



